### PR TITLE
Feat / 비밀번호 찾기, 발송 이메일 내용 수정

### DIFF
--- a/src/main/java/com/twat/detalks/config/WebMvcConfig.java
+++ b/src/main/java/com/twat/detalks/config/WebMvcConfig.java
@@ -1,0 +1,31 @@
+package com.twat.detalks.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${file.resource.path.mac}")
+    private String resourcePathMac;
+
+    @Value("${file.resource.path.win}")
+    private String resourcePathWin;
+
+    @Value("${file.resource.path.nix}")
+    private String resourcePathNix;
+
+    @Value("${file.upload.path}")
+    private String uploadPath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        WebMvcConfigurer.super.addResourceHandlers(registry);
+        registry.addResourceHandler(uploadPath)
+            .addResourceLocations(resourcePathMac)
+            .addResourceLocations(resourcePathWin)
+            .addResourceLocations(resourcePathNix);
+    }
+}

--- a/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
+++ b/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
@@ -80,8 +80,8 @@ public class WebSecurityConfig {
                 .requestMatchers("/api/member/name/**").permitAll() // 이름 중복체크
                 .requestMatchers("/api/member/signin").permitAll() //  일반 로그인
                 .requestMatchers("/api/member/auth/header").permitAll() // 소셜 로그인
-                .requestMatchers("/api/email").permitAll() // 이메일 인증
-                .requestMatchers("/api/member/pwd").permitAll() // 이메일 인증
+                .requestMatchers("/api/email/**").permitAll() // 이메일 인증
+                .requestMatchers("/api/member/pwd").permitAll() // 비밀번호 재설정
                 .requestMatchers(HttpMethod.GET,"/api/questions/**").permitAll() // 질문 조회 관련
                 .requestMatchers(("/api/mypage/**")).permitAll() // 마이 페이지 관련
                 .anyRequest().authenticated()

--- a/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
+++ b/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
@@ -108,7 +108,8 @@ public class WebSecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
-            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+            .requestMatchers("/upload/**"); // 정적 파일경로 제외
     }
 
 }

--- a/src/main/java/com/twat/detalks/member/controller/EmailController.java
+++ b/src/main/java/com/twat/detalks/member/controller/EmailController.java
@@ -15,10 +15,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 public class EmailController {
+
     private final EmailService emailService;
+
     @PostMapping
     public String mailConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
         int num = emailService.sendEmail(verifyEmailDto.getEmail());
         return "인증 코드 :: " + num;
     }
+
+    @PostMapping("/password")
+    public String passwordConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
+        int num = emailService.sendFindMail(verifyEmailDto.getEmail());
+        return "인증 코드 :: " + num;
+    }
+
 }

--- a/src/main/java/com/twat/detalks/member/service/EmailService.java
+++ b/src/main/java/com/twat/detalks/member/service/EmailService.java
@@ -22,7 +22,7 @@ public class EmailService {
         number = (int)(Math.random() * (900000)) + 100000; // 100000부터 999999 사이의 난수 생성
     }
 
-    // 메일 양식 작성
+    // 회원 가입용 메일폼
     public MimeMessage createMail(String email){
         createNumber();  // 인증 코드 생성
         MimeMessage message = javaMailSender.createMimeMessage();
@@ -51,6 +51,35 @@ public class EmailService {
         return message;
     }
 
+    // 비밀 번호 찾기용 메일폼
+    public MimeMessage findPasswordMail(String email){
+        createNumber();  // 인증 코드 생성
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            message.setFrom(senderEmail);   // 보내는 이메일
+            message.setRecipients(MimeMessage.RecipientType.TO, email); // 보낼 이메일 설정
+            message.setSubject("[DeTalks] 비밀번호 재설정을 위한 이메일 인증");  // 제목 설정
+            String body = "";
+            body += "<h1>" + "안녕하세요." + "</h1>";
+            body += "<h1>" + "Detalks 입니다." + "</h1>";
+            body += "<h3>" + "비밀번호 재설정을 위해 요청하신 인증 번호입니다." + "</h3><br>";
+            body += "<h2>" + "아래 코드를 비밀번호 재설정 창으로 돌아가 입력해주세요." + "</h2>";
+
+            body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
+            body += "<h2>" + "인증 코드입니다." + "</h2>";
+            body += "<h1 style='color:blue'>" + number + "</h1>";
+            body += "</div><br>";
+            body += "<h3>" + "감사합니다." + "</h3>";
+            message.setText(body, "UTF-8", "html");
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to create email message", e);
+        }
+
+        return message;
+    }
+
     // 실제 메일 전송
     public int sendEmail(String email) {
         // 메일 전송에 필요한 정보 설정
@@ -58,6 +87,12 @@ public class EmailService {
         // 실제 메일 전송
         javaMailSender.send(message);
         // 인증 코드 반환
+        return number;
+    }
+
+    public int sendFindMail(String email){
+        MimeMessage message = findPasswordMail(email);
+        javaMailSender.send(message);
         return number;
     }
 }

--- a/src/main/java/com/twat/detalks/member/service/MemberService.java
+++ b/src/main/java/com/twat/detalks/member/service/MemberService.java
@@ -11,7 +11,6 @@ import com.twat.detalks.member.vo.Social;
 import com.twat.detalks.question.repository.QuestionRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -49,20 +48,33 @@ public class MemberService {
     public MemberService(MemberRepository memberRepository,
                          QuestionRepository questionRepository,
                          AnswerRepositroy answerRepositroy,
-                         BCryptPasswordEncoder passwordEncoder,
-                         @Value("${file.upload-dir}") String uploadDir) {
+                         BCryptPasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
-        this.fileStorageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
-        this.questionRepository = questionRepository;
-        this.answerRepositroy = answerRepositroy;
-
+        this.fileStorageLocation = setFileStorageLocation();
         try {
             Files.createDirectories(this.fileStorageLocation); // 파일 저장 디렉토리가 없으면 생성
         } catch (Exception e) {
             throw new RuntimeException("디렉토리 생성 오류");
         }
+        this.questionRepository = questionRepository;
+        this.answerRepositroy = answerRepositroy;
     }
+
+    // 운영체제에 따른 파일 저장 경로 설정 메서드
+    private Path setFileStorageLocation() {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return Paths.get("C:\\upload").toAbsolutePath().normalize();
+        } else if (os.contains("mac")) {
+            return Paths.get("/Users/jarajiri/upload").toAbsolutePath().normalize();
+        } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
+            return Paths.get("/home/ubuntu/detalks/server/upload").toAbsolutePath().normalize();
+        } else {
+            throw new IllegalStateException("Unsupported OS: " + os);
+        }
+    }
+
 
     // 이메일 유효성 검사
     public void regexEmailCheck(final String email) {


### PR DESCRIPTION
[FEAT / 비밀번호 찾기 이메일 인증 API]

- 비밀번호 찾기시 회원가입용 메일화면이랑 다른 비밀번호 찾기 전용 메일 화면 구성
- api 경로
- POST /api/email/password

[FIX / 프로필 이미지 지연 로딩]

- 프로젝트 내부에 있을경우 이미지 업로드 속도보다 컴파일 속도가 빨라 화면에 지연로딩이 발생함
- 업로드 이미지 파일 프로젝트 외부 경로로 설정 변경
- 윈도우 / 맥 / 우분투 환경 파일 경로 동적 매핑