### PR TITLE
FEAT / REDIS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/twat/detalks/config/EmailConfig.java
+++ b/src/main/java/com/twat/detalks/config/EmailConfig.java
@@ -1,0 +1,67 @@
+package com.twat.detalks.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/twat/detalks/config/RedisConfig.java
+++ b/src/main/java/com/twat/detalks/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.twat.detalks.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(host);
+        redisConfig.setPort(port);
+        redisConfig.setPassword(password); // 비밀번호 설정
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
+++ b/src/main/java/com/twat/detalks/config/WebSecurityConfig.java
@@ -80,6 +80,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/api/member/signin").permitAll() //  일반 로그인
                 .requestMatchers("/api/member/auth/header").permitAll() // 소셜 로그인
                 .requestMatchers("/api/email/**").permitAll() // 이메일 인증
+                // .requestMatchers("/api/v1/email/**").permitAll()
                 .requestMatchers("/api/member/pwd").permitAll() // 비밀번호 재설정
                 .requestMatchers(HttpMethod.GET,"/api/questions/**").permitAll() // 질문 조회 관련
                 // .requestMatchers("/api/votes/**").permitAll() // 투표

--- a/src/main/java/com/twat/detalks/email/controller/EmailController.java
+++ b/src/main/java/com/twat/detalks/email/controller/EmailController.java
@@ -1,0 +1,64 @@
+package com.twat.detalks.email.controller;
+
+import com.twat.detalks.email.dto.EmailDto;
+import com.twat.detalks.email.service.EmailService;
+import com.twat.detalks.member.dto.ResDto;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+public class EmailController {
+    private final EmailService emailService;
+
+    // 회원가입 인증코드 메일 발송
+    @PostMapping("/send")
+    public ResponseEntity<?> signUpMailSend(@RequestBody EmailDto emailDto) throws MessagingException {
+        emailService.signUpSendEmail(emailDto.getEmail());
+        return ResponseEntity.ok().body(
+            ResDto.builder()
+                .msg("인증 코드가 발송되었습니다.")
+                .result(true)
+                .build());
+    }
+
+    // 인증코드 검증
+    @PostMapping("/verify")
+    public ResponseEntity<ResDto> verify(@RequestBody EmailDto emailDto) {
+        boolean isVerify = emailService.verifyEmailCode(emailDto.getEmail(), emailDto.getCode());
+        if (isVerify) {
+            return ResponseEntity.ok().body(
+                ResDto.builder()
+                    .msg("인증이 완료되었습니다.")
+                    .result(true)
+                    .build());
+        } else {
+            return ResponseEntity.badRequest().body(
+                ResDto.builder()
+                    .msg("인증에 실패하셨습니다.")
+                    .result(false)
+                    .build());
+        }
+    }
+
+    // 회원가입 인증코드 메일 발송
+    @PostMapping("/password/send")
+    public ResponseEntity<?> findPwdMailSend(@RequestBody EmailDto emailDto) throws MessagingException {
+        emailService.findPwdSendEmail(emailDto.getEmail());
+        return ResponseEntity.ok().body(
+            ResDto.builder()
+                .msg("인증 코드가 발송되었습니다.")
+                .result(true)
+                .build());
+    }
+
+
+}

--- a/src/main/java/com/twat/detalks/email/dto/EmailDto.java
+++ b/src/main/java/com/twat/detalks/email/dto/EmailDto.java
@@ -1,0 +1,18 @@
+package com.twat.detalks.email.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class EmailDto {
+
+    // 이메일
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
+    @Schema(description = "이메일 주소", example = "테스트 가능한 본인 이메일 주소")
+    private String email;
+    // 인증 코드
+    private String code;
+}

--- a/src/main/java/com/twat/detalks/email/entity/Email.java
+++ b/src/main/java/com/twat/detalks/email/entity/Email.java
@@ -1,0 +1,31 @@
+package com.twat.detalks.email.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "email")
+public class Email {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "email_id", unique = true, nullable = false)
+    private Long id;
+
+    // 이메일 주소
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    // 이메일 인증 여부
+    @Column(name = "email_status", nullable = false)
+    private boolean emailStatus;
+
+    @Builder
+    public Email(String email) {
+        this.email = email;
+        this.emailStatus = false;
+    }
+}

--- a/src/main/java/com/twat/detalks/email/repository/EmailRepository.java
+++ b/src/main/java/com/twat/detalks/email/repository/EmailRepository.java
@@ -1,0 +1,13 @@
+package com.twat.detalks.email.repository;
+
+import com.twat.detalks.email.entity.Email;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailRepository extends JpaRepository<Email, Long> {
+    // 인증코드 발송한 이메일 주소 조회
+    Optional<Email> findByEmail(String email);
+}

--- a/src/main/java/com/twat/detalks/email/service/EmailService.java
+++ b/src/main/java/com/twat/detalks/email/service/EmailService.java
@@ -1,0 +1,123 @@
+package com.twat.detalks.email.service;
+
+import com.twat.detalks.email.util.RedisUtil;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final RedisUtil redisUtil;
+
+    @Value("${mail.sender.email}")
+    private static String senderEmail = null;
+
+    private String createCode() {
+        int leftLimit = 48; // number '0'
+        int rightLimit = 122; // alphabet 'z'
+        int targetStringLength = 6;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+            .filter(i -> (i <= 57 || i >= 65) && (i <= 90 | i >= 97))
+            .limit(targetStringLength)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    // 회원가입 이메일 폼 생성
+    private MimeMessage createSignUpEmailForm(String email) throws MessagingException {
+        String authCode = createCode();
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+        message.setSubject("[DeTalks] 회원가입을 위한 이메일 인증");  // 제목 설정
+        String body = "";
+        body += "<h1>" + "안녕하세요." + "</h1>";
+        body += "<h1>" + "Detalks 입니다." + "</h1>";
+        body += "<h3>" + "회원가입을 위한 요청하신 인증 번호입니다." + "</h3><br>";
+        body += "<h2>" + "아래 코드를 회원가입 창으로 돌아가 입력해주세요." + "</h2>";
+
+        body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
+        body += "<h2>" + "회원가입 인증 코드입니다." + "</h2>";
+        body += "<h1 style='color:blue'>" + authCode + "</h1>";
+        body += "</div><br>";
+        body += "<h3>" + "감사합니다." + "</h3>";
+        message.setText(body, "UTF-8", "html");
+
+        // Redis 에 해당 인증코드 인증 시간 설정
+        redisUtil.setDataExpire(email, authCode, 60 * 30L);
+
+        return message;
+    }
+
+    // 비밀번호 찾기 이메일 폼 생성
+    private MimeMessage createFindPwdEmailForm(String email) throws MessagingException {
+        String authCode = createCode();
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+        message.setSubject("[DeTalks] 비밀번호 초기화를 위한 이메일 인증");  // 제목 설정
+        String body = "";
+        body += "<h1>" + "안녕하세요." + "</h1>";
+        body += "<h1>" + "Detalks 입니다." + "</h1>";
+        body += "<h3>" + "비밀번호 초기화를 위해 요청하신 인증 번호입니다." + "</h3><br>";
+        body += "<h2>" + "아래 코드를 비밀번호 찾기로 돌아가 입력해주세요." + "</h2>";
+
+        body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
+        body += "<h2>" + "비밀번호 초기화 인증 코드입니다." + "</h2>";
+        body += "<h1 style='color:blue'>" + authCode + "</h1>";
+        body += "</div><br>";
+        body += "<h3>" + "감사합니다." + "</h3>";
+        message.setText(body, "UTF-8", "html");
+
+        // Redis 에 해당 인증코드 인증 시간 설정
+        redisUtil.setDataExpire(email, authCode, 60 * 30L);
+
+        return message;
+    }
+
+    // 회원가입 인증코드 이메일 발송
+    public void signUpSendEmail(String toEmail) throws MessagingException {
+        if (redisUtil.existData(toEmail)) {
+            redisUtil.deleteData(toEmail);
+        }
+        // 이메일 폼 생성
+        MimeMessage emailForm = createSignUpEmailForm(toEmail);
+        // 이메일 발송
+        javaMailSender.send(emailForm);
+    }
+
+    // 비밀번호 찾기 인증코드 이메일 발송
+    public void findPwdSendEmail(String toEmail) throws MessagingException {
+        if (redisUtil.existData(toEmail)) {
+            redisUtil.deleteData(toEmail);
+        }
+        // 이메일 폼 생성
+        MimeMessage emailForm = createFindPwdEmailForm(toEmail);
+        // 이메일 발송
+        javaMailSender.send(emailForm);
+    }
+
+    // 인증코드 검증
+    public Boolean verifyEmailCode(String email, String code) {
+        String codeFoundByEmail = redisUtil.getData(email);
+        log.info("code found by email: " + codeFoundByEmail);
+        if (codeFoundByEmail == null) {
+            return false;
+        }
+        return codeFoundByEmail.equals(code);
+    }
+}

--- a/src/main/java/com/twat/detalks/email/util/RedisUtil.java
+++ b/src/main/java/com/twat/detalks/email/util/RedisUtil.java
@@ -1,0 +1,33 @@
+package com.twat.detalks.email.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final StringRedisTemplate template;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(template.hasKey(key));
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        template.delete(key);
+    }
+}

--- a/src/main/java/com/twat/detalks/member/controller/EmailController.java
+++ b/src/main/java/com/twat/detalks/member/controller/EmailController.java
@@ -1,38 +1,38 @@
-package com.twat.detalks.member.controller;
-
-import com.twat.detalks.member.dto.VerifyEmailDto;
-import com.twat.detalks.member.service.EmailService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/api/email")
-@RequiredArgsConstructor
-@Tag(name = "이메일 인증 API", description = "")
-@Slf4j
-public class EmailController {
-
-    private final EmailService emailService;
-
-    @PostMapping
-    @Operation(summary = "이메일 인증메일 발송  (회원가입)")
-    public String mailConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
-        int num = emailService.sendEmail(verifyEmailDto.getEmail());
-        return "인증 코드 :: " + num;
-    }
-
-    @PostMapping("/password")
-    @Operation(summary = "이메일 인증메일 발송  (비밀번호 찾기)")
-    public String passwordConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
-        int num = emailService.sendFindMail(verifyEmailDto.getEmail());
-        return "인증 코드 :: " + num;
-    }
-
-}
+// package com.twat.detalks.member.controller;
+//
+// import com.twat.detalks.member.dto.VerifyEmailDto;
+// import com.twat.detalks.member.service.EmailService;
+// import io.swagger.v3.oas.annotations.Operation;
+// import io.swagger.v3.oas.annotations.tags.Tag;
+// import jakarta.validation.Valid;
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+// import org.springframework.web.bind.annotation.PostMapping;
+// import org.springframework.web.bind.annotation.RequestBody;
+// import org.springframework.web.bind.annotation.RequestMapping;
+// import org.springframework.web.bind.annotation.RestController;
+//
+// @RestController
+// @RequestMapping("/api/email")
+// @RequiredArgsConstructor
+// @Tag(name = "이메일 인증 API", description = "")
+// @Slf4j
+// public class EmailController {
+//
+//     private final EmailService emailService;
+//
+//     @PostMapping
+//     @Operation(summary = "이메일 인증메일 발송  (회원가입)")
+//     public String mailConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
+//         int num = emailService.sendEmail(verifyEmailDto.getEmail());
+//         return "인증 코드 :: " + num;
+//     }
+//
+//     @PostMapping("/password")
+//     @Operation(summary = "이메일 인증메일 발송  (비밀번호 찾기)")
+//     public String passwordConfirm(@RequestBody @Valid VerifyEmailDto verifyEmailDto) {
+//         int num = emailService.sendFindMail(verifyEmailDto.getEmail());
+//         return "인증 코드 :: " + num;
+//     }
+//
+// }

--- a/src/main/java/com/twat/detalks/member/dto/VerifyEmailDto.java
+++ b/src/main/java/com/twat/detalks/member/dto/VerifyEmailDto.java
@@ -1,18 +1,18 @@
-package com.twat.detalks.member.dto;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-public class VerifyEmailDto {
-
-    @NotBlank(message = "이메일은 필수 입력 값입니다.")
-    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
-    @Schema(description = "이메일 주소", example = "테스트 가능한 본인 이메일 주소")
-    private String email;
-}
+// package com.twat.detalks.member.dto;
+//
+// import io.swagger.v3.oas.annotations.media.Schema;
+// import jakarta.validation.constraints.NotBlank;
+// import jakarta.validation.constraints.Pattern;
+// import lombok.AllArgsConstructor;
+// import lombok.Builder;
+// import lombok.Getter;
+// import lombok.NoArgsConstructor;
+//
+// @Getter
+// public class VerifyEmailDto {
+//
+//     @NotBlank(message = "이메일은 필수 입력 값입니다.")
+//     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,}$", message = "이메일 형식이 올바르지 않습니다.")
+//     @Schema(description = "이메일 주소", example = "테스트 가능한 본인 이메일 주소")
+//     private String email;
+// }

--- a/src/main/java/com/twat/detalks/member/service/EmailService.java
+++ b/src/main/java/com/twat/detalks/member/service/EmailService.java
@@ -1,98 +1,98 @@
-package com.twat.detalks.member.service;
-
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.stereotype.Service;
-
-@Service
-@RequiredArgsConstructor
-public class EmailService {
-
-    private final JavaMailSender javaMailSender;  // 의존성 주입을 통해 필요한 객체를 가져옴
-
-    @Value("${mail.sender.email}")
-    private String senderEmail;  // application.properties에서 값 주입
-
-    private static int number;  // 랜덤 인증 코드
-
-    // 랜덤 인증 코드 생성
-    public static void createNumber() {
-        number = (int)(Math.random() * (900000)) + 100000; // 100000부터 999999 사이의 난수 생성
-    }
-
-    // 회원 가입용 메일폼
-    public MimeMessage createMail(String email){
-        createNumber();  // 인증 코드 생성
-        MimeMessage message = javaMailSender.createMimeMessage();
-
-        try {
-            message.setFrom(senderEmail);   // 보내는 이메일
-            message.setRecipients(MimeMessage.RecipientType.TO, email); // 보낼 이메일 설정
-            message.setSubject("[DeTalks] 회원가입을 위한 이메일 인증");  // 제목 설정
-            String body = "";
-            body += "<h1>" + "안녕하세요." + "</h1>";
-            body += "<h1>" + "Detalks 입니다." + "</h1>";
-            body += "<h3>" + "회원가입을 위한 요청하신 인증 번호입니다." + "</h3><br>";
-            body += "<h2>" + "아래 코드를 회원가입 창으로 돌아가 입력해주세요." + "</h2>";
-
-            body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
-            body += "<h2>" + "회원가입 인증 코드입니다." + "</h2>";
-            body += "<h1 style='color:blue'>" + number + "</h1>";
-            body += "</div><br>";
-            body += "<h3>" + "감사합니다." + "</h3>";
-            message.setText(body, "UTF-8", "html");
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to create email message", e);
-        }
-
-        return message;
-    }
-
-    // 비밀 번호 찾기용 메일폼
-    public MimeMessage findPasswordMail(String email){
-        createNumber();  // 인증 코드 생성
-        MimeMessage message = javaMailSender.createMimeMessage();
-
-        try {
-            message.setFrom(senderEmail);   // 보내는 이메일
-            message.setRecipients(MimeMessage.RecipientType.TO, email); // 보낼 이메일 설정
-            message.setSubject("[DeTalks] 비밀번호 재설정을 위한 이메일 인증");  // 제목 설정
-            String body = "";
-            body += "<h1>" + "안녕하세요." + "</h1>";
-            body += "<h1>" + "Detalks 입니다." + "</h1>";
-            body += "<h3>" + "비밀번호 재설정을 위해 요청하신 인증 번호입니다." + "</h3><br>";
-            body += "<h2>" + "아래 코드를 비밀번호 재설정 창으로 돌아가 입력해주세요." + "</h2>";
-
-            body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
-            body += "<h2>" + "인증 코드입니다." + "</h2>";
-            body += "<h1 style='color:blue'>" + number + "</h1>";
-            body += "</div><br>";
-            body += "<h3>" + "감사합니다." + "</h3>";
-            message.setText(body, "UTF-8", "html");
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to create email message", e);
-        }
-
-        return message;
-    }
-
-    // 실제 메일 전송
-    public int sendEmail(String email) {
-        // 메일 전송에 필요한 정보 설정
-        MimeMessage message = createMail(email);
-        // 실제 메일 전송
-        javaMailSender.send(message);
-        // 인증 코드 반환
-        return number;
-    }
-
-    public int sendFindMail(String email){
-        MimeMessage message = findPasswordMail(email);
-        javaMailSender.send(message);
-        return number;
-    }
-}
+// package com.twat.detalks.member.service;
+//
+// import jakarta.mail.internet.MimeMessage;
+// import lombok.RequiredArgsConstructor;
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.mail.javamail.JavaMailSender;
+// import org.springframework.stereotype.Service;
+//
+// @Service
+// @RequiredArgsConstructor
+// public class EmailService {
+//
+//     private final JavaMailSender javaMailSender;  // 의존성 주입을 통해 필요한 객체를 가져옴
+//
+//     @Value("${mail.sender.email}")
+//     private String senderEmail;  // application.properties에서 값 주입
+//
+//     private static int number;  // 랜덤 인증 코드
+//
+//     // 랜덤 인증 코드 생성
+//     public static void createNumber() {
+//         number = (int)(Math.random() * (900000)) + 100000; // 100000부터 999999 사이의 난수 생성
+//     }
+//
+//     // 회원 가입용 메일폼
+//     public MimeMessage createMail(String email){
+//         createNumber();  // 인증 코드 생성
+//         MimeMessage message = javaMailSender.createMimeMessage();
+//
+//         try {
+//             message.setFrom(senderEmail);   // 보내는 이메일
+//             message.setRecipients(MimeMessage.RecipientType.TO, email); // 보낼 이메일 설정
+//             message.setSubject("[DeTalks] 회원가입을 위한 이메일 인증");  // 제목 설정
+//             String body = "";
+//             body += "<h1>" + "안녕하세요." + "</h1>";
+//             body += "<h1>" + "Detalks 입니다." + "</h1>";
+//             body += "<h3>" + "회원가입을 위한 요청하신 인증 번호입니다." + "</h3><br>";
+//             body += "<h2>" + "아래 코드를 회원가입 창으로 돌아가 입력해주세요." + "</h2>";
+//
+//             body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
+//             body += "<h2>" + "회원가입 인증 코드입니다." + "</h2>";
+//             body += "<h1 style='color:blue'>" + number + "</h1>";
+//             body += "</div><br>";
+//             body += "<h3>" + "감사합니다." + "</h3>";
+//             message.setText(body, "UTF-8", "html");
+//         } catch (Exception e) {
+//             e.printStackTrace();
+//             throw new RuntimeException("Failed to create email message", e);
+//         }
+//
+//         return message;
+//     }
+//
+//     // 비밀 번호 찾기용 메일폼
+//     public MimeMessage findPasswordMail(String email){
+//         createNumber();  // 인증 코드 생성
+//         MimeMessage message = javaMailSender.createMimeMessage();
+//
+//         try {
+//             message.setFrom(senderEmail);   // 보내는 이메일
+//             message.setRecipients(MimeMessage.RecipientType.TO, email); // 보낼 이메일 설정
+//             message.setSubject("[DeTalks] 비밀번호 재설정을 위한 이메일 인증");  // 제목 설정
+//             String body = "";
+//             body += "<h1>" + "안녕하세요." + "</h1>";
+//             body += "<h1>" + "Detalks 입니다." + "</h1>";
+//             body += "<h3>" + "비밀번호 재설정을 위해 요청하신 인증 번호입니다." + "</h3><br>";
+//             body += "<h2>" + "아래 코드를 비밀번호 재설정 창으로 돌아가 입력해주세요." + "</h2>";
+//
+//             body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
+//             body += "<h2>" + "인증 코드입니다." + "</h2>";
+//             body += "<h1 style='color:blue'>" + number + "</h1>";
+//             body += "</div><br>";
+//             body += "<h3>" + "감사합니다." + "</h3>";
+//             message.setText(body, "UTF-8", "html");
+//         } catch (Exception e) {
+//             e.printStackTrace();
+//             throw new RuntimeException("Failed to create email message", e);
+//         }
+//
+//         return message;
+//     }
+//
+//     // 실제 메일 전송
+//     public int sendEmail(String email) {
+//         // 메일 전송에 필요한 정보 설정
+//         MimeMessage message = createMail(email);
+//         // 실제 메일 전송
+//         javaMailSender.send(message);
+//         // 인증 코드 반환
+//         return number;
+//     }
+//
+//     public int sendFindMail(String email){
+//         MimeMessage message = findPasswordMail(email);
+//         javaMailSender.send(message);
+//         return number;
+//     }
+// }


### PR DESCRIPTION
- redis 의존성 추가 및 설정
- 회원가입/비밀번호 찾기시 사용하는 인증코드의 보안 강화 목적으로 서버에서 인증코드 검증하는 로직 추가
- 인증코드는 장기적으로 저장할 필요가 없으므로 인메모리 방식의 redis가 적합
- 기존 이메일 인증 컨트롤러/서비스/dto/레포지토리 코드 주석처리
- 폴더구조에 email 도메인 추가해서 리팩토링
- 시큐리티